### PR TITLE
Fix stress test initialization in Humanizer

### DIFF
--- a/scenes/tests/humanizer_stress_test.tscn
+++ b/scenes/tests/humanizer_stress_test.tscn
@@ -64,7 +64,7 @@ func _process(delta) -> void:
 func _generate_human() -> void:
 	print('starting new human')
 	var human = Humanizer.new()
-	human.load_human()
+	human.load_human(true)
 	
 	print('randomizing')
 	randomizer.human = human

--- a/scripts/humanizer.gd
+++ b/scripts/humanizer.gd
@@ -110,7 +110,7 @@ var eye_color: Color = _DEFAULT_EYE_COLOR:
 			human_config.rig = HumanizerGlobalConfig.config.default_skeleton
 		# This gets set before _ready causing issues so make sure we're loaded
 		if scene_loaded:
-			_load_human()
+			load_human()
 ## The new shapekeys which have been defined for this human.  These will survive the baking process.
 @export var new_shapekeys: Dictionary = {}
 
@@ -155,7 +155,7 @@ func _ready() -> void:
 		if child.name.begins_with('Baked-'):
 			baked = true
 	if not baked:
-		_load_human()
+		load_human()
 	scene_loaded = true
 
 ####  HumanConfig Resource Management ####
@@ -185,14 +185,16 @@ func _get_asset_by_name(mesh_name: String) -> HumanAsset:
 				res = cl as HumanClothes
 	return res
 
-func _load_human() -> void:
+func load_human(reset: bool = false) -> void:
 	## if we are calling on a node ont in the tree ready won't be called
 	if human_config == null and not scene_loaded:
 		human_config = HumanConfig.new()
 	baked = false
-	reset_human()
+	if (reset):
+		reset_human()
 	_deserialize()
 	notify_property_list_changed()
+	
 
 func _deserialize() -> void:
 	# Since shapekeys are relative we start from empty


### PR DESCRIPTION
The stress test initialization in the Humanizer project was not functioning correctly. This commit fixes the issue by ensuring that the load_human function is called with the appropriate parameter true to correctly initialize the stress test. Additionally, the load_human function has been modified to accept a boolean parameter reset, allowing for more flexible initialization behavior. This ensures that the stress test can be properly conducted without encountering initialization errors.

The Fix to #7 