### PR TITLE
fix crash on exported projects

### DIFF
--- a/scripts/resources/humanizer_rig.gd
+++ b/scripts/resources/humanizer_rig.gd
@@ -16,9 +16,10 @@ func load_retargeted_skeleton() -> Skeleton3D:
 	return load(skeleton_retargeted_path).instantiate()
 
 func load_bone_weights() -> Dictionary:
-	var weights: Dictionary = HumanizerUtils.read_json(mh_weights_path).weights
-	for in_name:String in weights.keys():
-		if ':' not in in_name:
+	var json := FileAccess.get_file_as_string(mh_weights_path)
+	var weights: Dictionary = JSON.parse_string(json).weights
+	for in_name: String in weights.keys():
+		if ":" not in in_name:
 			continue
 		var out_name = in_name.replace(":", "_")
 		weights[out_name] = weights[in_name]


### PR DESCRIPTION
This change fixes https://github.com/NitroxNova/Humanizer/issues/13

**Context**
Exported project crashes on start. I did a bit of digging and apparently `HumanizerUtils` depends on `EditorInterface` which is fine but probably we don't want this to be "compiled" for the exported project.

I removed this dependency by duplicating the contents of `read_json` static function. IMO a bit of duplication is better than a bit of dependency :)

Personal opinion: I would probably avoid having a single utils class of any kind to avoid dependency hell in future.