### PR TITLE
Allow unsetting of material textures

### DIFF
--- a/scripts/resources/humanizer_material.gd
+++ b/scripts/resources/humanizer_material.gd
@@ -20,6 +20,7 @@ func update_material() -> void:
 		var image: Image = null
 		var path = overlays[0].get(texture + '_texture_path')
 		if path == '':
+			set(texture + '_texture', null)
 			continue
 		image = load(path).get_image()
 		base_size = image.get_size()


### PR DESCRIPTION
This makes selecting "NONE" for the normal skin work. Currently once you select a normal skin, selecting NONE will do nothing, and leave the currently selected normal texture assigned.