### PR TITLE
Minor Changes to remove errors after compiling

### DIFF
--- a/addons/humanizer/scenes/humanizer_global.tscn
+++ b/addons/humanizer/scenes/humanizer_global.tscn
@@ -10,6 +10,15 @@ extends Node
 
 # called when enters the editor AND when enters the game
 func _ready() -> void:
+	var path = "res://humanizer"
+	if not DirAccess.dir_exists_absolute(path):
+		DirAccess.make_dir_absolute(path)
+	if not DirAccess.dir_exists_absolute(path+"/target"):
+		DirAccess.make_dir_absolute(path+"/target")
+	if not DirAccess.dir_exists_absolute(path+"/material"):
+		DirAccess.make_dir_absolute(path+"/material")
+	if not DirAccess.dir_exists_absolute(path+"/equipment"):
+		DirAccess.make_dir_absolute(path+"/equipment")
 	HumanizerRegistry._get_rigs()
 	if Engine.is_editor_hint():
 		pass

--- a/addons/humanizer/scripts/utils/os_path.gd
+++ b/addons/humanizer/scripts/utils/os_path.gd
@@ -31,11 +31,14 @@ static func save_json(file_path, data):
 
 static func get_files_recursive(path:String):
 	var paths = []
-	#if not DirAccess.dir_exists_absolute(path): #dont do this, it returns false when loaded from zip, but get_files_at still works..
-	for file in DirAccess.get_files_at(path):
-		paths.append(path.path_join(file))
-	for dir in DirAccess.get_directories_at(path):
-		paths.append_array(get_files_recursive(path.path_join(dir)))
+	var pathexists=true
+	if not DirAccess.dir_exists_absolute(path):
+		pathexists=false
+	if pathexists:
+		for file in DirAccess.get_files_at(path):
+			paths.append(path.path_join(file))
+		for dir in DirAccess.get_directories_at(path):
+			paths.append_array(get_files_recursive(path.path_join(dir)))
 	return paths
 
 static func get_contents(path: String) -> Dictionary:


### PR DESCRIPTION
There were several "folders not found" errors that were popping up after compiling. These are the fixes that made them go away. 